### PR TITLE
Fix snapcraft.yaml syntax

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,12 +26,9 @@ parts:
     randip_nim:
       plugin: dump
       source: snap/
-      override_build: |
-      snapcraftctl build
-      chmod +x randip_nim
-      
-
-    
+      override-build: |
+        snapcraftctl build
+        chmod +x randip_nim
 
 apps:
   randip:


### PR DESCRIPTION
The key is called `override-build` rather than `override_build`, and the extra indentation is needed for the file to parse as valid YAML.